### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-pipeline.yml
+++ b/.github/workflows/build-pipeline.yml
@@ -1,4 +1,6 @@
 name: dev-tool-box
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RHSplinter/DevToolBox/security/code-scanning/1](https://github.com/RHSplinter/DevToolBox/security/code-scanning/1)

To fix the workflow's missing permissions block, add a `permissions:` section with the least permissions required by all jobs. Since these jobs mostly read the repository contents and upload/download artifacts, the minimal starting set is `contents: read`. Add the block at the root level, below the `name:` and before `on:`—this will apply to all jobs unless overridden. No code outside the workflow file needs changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
