### PR TITLE
Improve Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,32 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # NPM dependency updates
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "saturday"
       time: "13:01"
+    open-pull-requests-limit: 10
     groups:
-      npm-dependencies:
+      npm-dependencies-minor:
+        update-types:
+          - minor
+          - patch
+      npm-dependencies-major:
+        update-types:
+          - major
+
+  # GitHub Actions updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+      time: "13:01"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-dependencies:
         patterns:
           - "*"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to provide more granular control over dependency updates for both NPM packages and GitHub Actions. The changes improve how updates are grouped and managed, making it easier to handle different types of updates separately and avoid overwhelming the repository with too many pull requests.

Dependency update configuration improvements:

* Split NPM dependency updates into two groups: one for minor and patch updates (`npm-dependencies-minor`) and one for major updates (`npm-dependencies-major`), allowing for better separation and review of breaking vs. non-breaking changes.
* Set a limit of 10 open pull requests for NPM dependency updates to avoid excessive PRs.

Addition of GitHub Actions update management:

* Added a new configuration section for GitHub Actions dependencies, including a dedicated group (`github-actions-dependencies`) and a limit of 5 open pull requests, scheduled weekly.